### PR TITLE
Fixed Unicode error, csv must have reviews.text column

### DIFF
--- a/csv_to_langchain.py
+++ b/csv_to_langchain.py
@@ -65,8 +65,21 @@ class CSVLoader(BaseLoader):
         
     def load(self) -> List[Document]:
         # Load data into document objects
+        for fileEncoding in ["utf-8-sig", "utf-16", "utf-32"]:
+            try:
+                with open(self.file_path, newline="", encoding=fileEncoding) as csvfile:
+                    csv_reader = csv.DictReader(csvfile, **self.csv_args)
+                    for i, row in enumerate(csv_reader):
+                        continue
+                break
+            except UnicodeDecodeError as e:
+                print(e)
+            except UnicodeError as e:
+                print(e)
+        else:
+            fileEncoding = "latin1"
         docs = []
-        with open(self.file_path, newline="", encoding="utf8") as csvfile:
+        with open(self.file_path, newline="", encoding=fileEncoding) as csvfile:
             csv_reader = csv.DictReader(csvfile, **self.csv_args)
             for i, row in enumerate(csv_reader):
                 content = ""


### PR DESCRIPTION
The Unicode errors have been fixed by iterating through the csv file and testing for different encodings.  It works as long as there is a 'reviews.text' column specifically.